### PR TITLE
Fix 500 error on removing post from subreddit with no stickies

### DIFF
--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -1429,7 +1429,7 @@ class Subreddit(Thing, Printable, BaseSite):
         # XXX: have to work with a copy of the list instead of modifying
         #   it directly, because it doesn't get marked as "dirty" and
         #   saved properly unless we assign a new list to the attr
-        sticky_fullnames = self.sticky_fullnames[:]
+        sticky_fullnames = self.sticky_fullnames[:] if self.sticky_fullnames is not None else []
         try:
             sticky_fullnames.remove(link._fullname)
         except ValueError:


### PR DESCRIPTION
To verify:

- create a subreddit
- make a post (don't sticky it)
- remove the post

You should see no 500 error on the /api/remove API call.