### PR TITLE
Removed effective_hot for sorting frontpage posts

### DIFF
--- a/r2/r2/lib/normalized_hot.py
+++ b/r2/r2/lib/normalized_hot.py
@@ -54,7 +54,7 @@ def get_hot_tuples(sr_ids, ageweight=None):
             # heapq.merge sorts from smallest to largest so we need to flip
             # ehot and hot to get the hottest links first
             tuples_by_srid[sr_id].append(
-                (-effective_hot, -hot, link_name, timestamp)
+                (-hot, -hot, link_name, timestamp)
             )
 
     return tuples_by_srid


### PR DESCRIPTION
Remove the normalized `effective_hot` value in favor of just the `hot` for sorting. This will keep old posts from quieter subreddits off the frontpage.

To test, pull the branch and reprovision or `sudo reddit-restart`.